### PR TITLE
Fix Compiler Errors with Clang and GCC 9+

### DIFF
--- a/include/inviwo/core/network/lambdanetworkvisitor.h
+++ b/include/inviwo/core/network/lambdanetworkvisitor.h
@@ -75,16 +75,16 @@ struct LambdaNetworkVisitor : NetworkVisitor, Funcs... {
 
     virtual bool visit([[maybe_unused]] Processor& processor) override {
         if constexpr (util::is_detected_exact_v<bool, ProcessorOverload, decltype(*this)>) {
-            return operator()(processor);
+            return this->operator()(processor);
         } else {
             return true;
         }
     }
     virtual bool visit([[maybe_unused]] CanvasProcessor& processor) override {
         if constexpr (util::is_detected_exact_v<bool, CanvasProcessorOverload, decltype(*this)>) {
-            return operator()(processor);
+            return this->operator()(processor);
         } else if constexpr (util::is_detected_exact_v<bool, ProcessorOverload, decltype(*this)>) {
-            return operator()(processor);
+            return this->operator()(processor);
         } else {
             return true;
         }
@@ -92,16 +92,16 @@ struct LambdaNetworkVisitor : NetworkVisitor, Funcs... {
 
     virtual bool visit([[maybe_unused]] Property& property) override {
         if constexpr (util::is_detected_exact_v<bool, PropertyOverload, decltype(*this)>) {
-            return operator()(property);
+            return this->operator()(property);
         } else {
             return true;
         }
     }
     virtual bool visit([[maybe_unused]] CompositeProperty& compositeProperty) override {
         if constexpr (util::is_detected_exact_v<bool, CompositePropertyOverload, decltype(*this)>) {
-            return operator()(compositeProperty);
+            return this->operator()(compositeProperty);
         } else if constexpr (util::is_detected_exact_v<bool, PropertyOverload, decltype(*this)>) {
-            return operator()(compositeProperty);
+            return this->operator()(compositeProperty);
         } else {
             return true;
         }

--- a/include/inviwo/core/resourcemanager/resourcemanagerobserver.h
+++ b/include/inviwo/core/resourcemanager/resourcemanagerobserver.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <string>
 #include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/util/observer.h>
 


### PR DESCRIPTION
This PR fixes some issues I encountered when compiling it with newer compiler versions.
- Add `this->` in front of `operator()`. Apparently this is no longer supported in newer GCC versions
- Add `#include <string.h>`. Apparently this is no longer transitively included *somewhere*

In addition to these changes, on my computer the following changes were also necessary:
- In cmake, disable: `IVW_USE_SIGAR`, `IVW_MODULE_FONTRENDERING`, `IVW_TEST_UNIT_TESTS`, `IVW_TEST_INTEGRATION_TESTS` and `IVW_TEST_UNIT_TESTS_RUN_ON_BUILD`
- Remove `inviwo-output/lib/freetype.so.6` and replace it with the one installed on your system, e.g. `ln -s /usr/lib64/freetype.so.6 inviwo-output/lib/freetype.so.6`. Use `fd freetype.so.6 /` to find the lib (or use `find`, don't know the syntax there).

Resubmit because I can't change the branch of an already existing PR.